### PR TITLE
[O2122] Fix problem with all-numeric database names

### DIFF
--- a/lib/OpenERP/XMLRPC/Client.pm
+++ b/lib/OpenERP/XMLRPC/Client.pm
@@ -234,6 +234,10 @@ sub simple_request
 {
     my $self = shift;
 
+    # I haven't forced dbname to be passed as string in here because it's possible other consumers of this class have
+    # used it in other ways where the dbname wasn't necessarily the second argument.  Therefore I've done it in
+    # each of its callers I know about.
+
     local *RPC::XML::boolean::value = sub {
         my $self = shift;
         # this fudges the false so it's not 0

--- a/lib/OpenERP/XMLRPC/Client.pm
+++ b/lib/OpenERP/XMLRPC/Client.pm
@@ -8,6 +8,8 @@ use Moose;
 use MIME::Base64;
 use failures qw/openerp::fault/;
 
+use RPC::XML qw/RPC_STRING/;
+
 
 has 'username' 	=> ( is  => 'ro', isa => 'Str', default => 'admin');
 has 'password' 	=> ( is  => 'ro', isa => 'Str', default => 'admin');
@@ -45,7 +47,7 @@ sub openerp_login
     my $self = shift;
 
     # call 'login' method to get the uid..
-    my $res = $self->openerp_rpc->send_request('login', $self->dbname, $self->username, \$self->password );
+    my $res = $self->openerp_rpc->send_request('login', RPC_STRING($self->dbname), $self->username, \$self->password );
 
     if ( ! defined $res || ! ref $res )
     {
@@ -119,7 +121,7 @@ sub object_execute
     $self->simple_request
 	(
 		'execute',
-		$self->dbname,
+		RPC_STRING($self->dbname),
 		$self->openerp_uid,
 		\$self->password,
 		$relation,
@@ -143,7 +145,7 @@ sub object_execute_kw
     $self->simple_request
 	(
 		'execute_kw',
-		$self->dbname,
+		RPC_STRING($self->dbname),
 		$self->openerp_uid,
 		\$self->password,
 		$relation,
@@ -167,7 +169,7 @@ sub object_exec_workflow
     $self->simple_request
 	(
 		'exec_workflow',
-		$self->dbname,
+		RPC_STRING($self->dbname),
 		$self->openerp_uid,
 		\$self->password,
 		$relation,
@@ -191,7 +193,7 @@ sub report_report
     return $self->simple_request
 	(
 		'report',
-		$self->dbname,
+		RPC_STRING($self->dbname),
 		$self->openerp_uid,
 		\$self->password,
 		$report_id,
@@ -213,7 +215,7 @@ sub report_report_get
     my $object = $self->simple_request
 	(
 		'report_get',
-		$self->dbname,
+		RPC_STRING($self->dbname),
 		$self->openerp_uid,
 		\$self->password,
 		$report_id,

--- a/lib/OpenERP/XMLRPC/Client.pm
+++ b/lib/OpenERP/XMLRPC/Client.pm
@@ -7,7 +7,6 @@ use 5.010;
 use Moose;
 use MIME::Base64;
 use failures qw/openerp::fault/;
-
 use RPC::XML qw/RPC_STRING/;
 
 


### PR DESCRIPTION
All-numeric database names where causing the following traceback from Odoo:

```
odoo-for-website_1  | 2019-10-04 10:16:14,661 1 ERROR 27082019 odoo.http: 'int' object has no attribute 'startswith'
odoo-for-website_1  | Traceback (most recent call last):
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 118, in dispatch_rpc
odoo-for-website_1  |     result = dispatch(method, params)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/service/common.py", line 57, in dispatch
odoo-for-website_1  |     return g[exp_method_name](*params)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/service/common.py", line 23, in exp_login
odoo-for-website_1  |     res = security.login(db, login, password)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/service/security.py", line 8, in login
odoo-for-website_1  |     res_users = odoo.registry(db)['res.users']
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/__init__.py", line 52, in registry
odoo-for-website_1  |     return modules.registry.Registry(database_name)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/modules/registry.py", line 59, in __new__
odoo-for-website_1  |     return cls.new(db_name)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/modules/registry.py", line 71, in new
odoo-for-website_1  |     registry.init(db_name)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/modules/registry.py", line 122, in init
odoo-for-website_1  |     self._db = odoo.sql_db.db_connect(db_name)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/sql_db.py", line 695, in db_connect
odoo-for-website_1  |     db, info = connection_info_for(to)
odoo-for-website_1  |   File "/usr/lib/python2.7/dist-packages/odoo/sql_db.py", line 669, in connection_info_for
odoo-for-website_1  |     if db_or_uri.startswith(('postgresql://', 'postgres://')):
odoo-for-website_1  | AttributeError: 'int' object has no attribute 'startswith'
odoo-for-website_1  | 2019-10-04 10:16:14,663 1 INFO 27082019 werkzeug: 172.21.0.12 - - [04/Oct/2019 10:16:14] "POST /xmlrpc/common HTTP/1.0" 200 -
```

This is due to weak typing and the DWIMmy nature of RPC::XML.

No tests because I don't believe we're in a position to control the test database names that are created for testing purposes.  In fact Test::MockOpenERP is written in Perl so we probably wouldn't be able to die in the same way when it's the wrong type anyway.

Not all modified methods tested, so please review very closely.