### PR TITLE
Set a copyright_holder in dist.ini so dzil build works

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,6 +2,7 @@ name    = OpenERP-XMLRPC-Simple
 author  = Benjamin Martin <ben@madeofpaper.co.uk>
 author  = Colin Newell <colin@opusvl.com>
 author  = Jon Allen (JJ) <jj@opusvl.com>
+copyright_holder = Colin Newell
 license = Perl_5
 
 [@Author::OpusVL::ToCPAN]

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = OpenERP-XMLRPC-Simple
 author  = Benjamin Martin <ben@madeofpaper.co.uk>
 author  = Colin Newell <colin@opusvl.com>
 author  = Jon Allen (JJ) <jj@opusvl.com>
-copyright_holder = Colin Newell
+copyright_holder = OpusVL <community@opusvl.com>
 license = Perl_5
 
 [@Author::OpusVL::ToCPAN]

--- a/dist.ini
+++ b/dist.ini
@@ -2,6 +2,7 @@ name    = OpenERP-XMLRPC-Simple
 author  = Benjamin Martin <ben@madeofpaper.co.uk>
 author  = Colin Newell <colin@opusvl.com>
 author  = Jon Allen (JJ) <jj@opusvl.com>
+author  = Nick Booker <nick.booker@opusvl.com>
 copyright_holder = OpusVL <community@opusvl.com>
 license = Perl_5
 


### PR DESCRIPTION
I've installed Colin as the copyright holder, because that will maintain
the status quo in the COPYRIGHT AND LICENSE section in
https://metacpan.org/pod/release/NEWELLC/OpenERP-XMLRPC-Simple-0.24/lib/OpenERP/XMLRPC/Client.pm

It might not be correct however, especially because in the release before that
the string was OpusVL:

https://metacpan.org/pod/release/NEWELLC/OpenERP-XMLRPC-Simple-0.23/lib/OpenERP/XMLRPC/Client.pm

Hence this review - perhaps it should be OpusVL